### PR TITLE
Fix intermittent panics caused by nil pointer dereferences in user and group processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 # SAM
 .aws-sam/

--- a/internal/idp/idp.go
+++ b/internal/idp/idp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/slashdevops/idp-scim-sync/internal/convert"
@@ -115,10 +116,16 @@ func (i *IdentityProvider) GetUsers(ctx context.Context, filter []string) (*mode
 		return uResult, nil
 	}
 
-	syncUsers := make([]*model.User, len(pUsers))
-	for i, usr := range pUsers {
+	syncUsers := make([]*model.User, 0, len(pUsers))
+	for _, usr := range pUsers {
 		gu := buildUser(usr)
-		syncUsers[i] = gu
+
+		// skip nil pointer
+		if gu == nil {
+			continue
+		}
+
+		syncUsers = append(syncUsers, gu)
 	}
 	uResult := model.UsersResultBuilder().WithResources(syncUsers).Build()
 
@@ -199,6 +206,12 @@ func (i *IdentityProvider) GetUsersByGroupsMembers(ctx context.Context, gmr *mod
 					return nil, fmt.Errorf("idp: error getting user: %+v, email: %s, error: %w", member.IPID, member.Email, err)
 				}
 				gu := buildUser(u)
+
+				// skip nil pointer
+				if gu == nil {
+					slog.Warn("idp: skipping member because it doesn't exists, buildUser() returned nil")
+					continue
+				}
 
 				log.Tracef("idp: GetUsersByGroupsMembers, user: %+v", convert.ToJSONString(gu))
 				pUsers = append(pUsers, gu)

--- a/internal/idp/idp.go
+++ b/internal/idp/idp.go
@@ -122,6 +122,7 @@ func (i *IdentityProvider) GetUsers(ctx context.Context, filter []string) (*mode
 
 		// skip nil pointer
 		if gu == nil {
+			slog.Warn("idp: error getting user: user does not exist, buildUsers() returned nil")
 			continue
 		}
 

--- a/internal/idp/idp_test.go
+++ b/internal/idp/idp_test.go
@@ -302,6 +302,42 @@ func TestGetUsers(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Should return UsersResult with filtered nil and no error",
+			prepare: func(f *fields) {
+				ctx := context.Background()
+				googleUsers := []*admin.User{
+					{
+						Id:           "1",
+						PrimaryEmail: "user.1@mail.com",
+						Name:         &admin.UserName{GivenName: "user", FamilyName: "1"},
+					},
+					{
+						Id:           "2",
+						PrimaryEmail: "", // This will cause buildUser to return nil
+						Name:         &admin.UserName{GivenName: "user", FamilyName: "2"},
+					},
+				}
+				f.ds.EXPECT().ListUsers(ctx, gomock.Eq([]string{""})).Return(googleUsers, nil).Times(1)
+			},
+			args: args{ctx: context.Background(), filter: []string{""}},
+			want: &model.UsersResult{
+				Items: 1,
+				Resources: []*model.User{
+					model.UserBuilder().
+						WithIPID("1").
+						WithName(&model.Name{GivenName: "user", FamilyName: "1"}).
+						WithDisplayName("user 1").
+						WithUserName("user.1@mail.com").
+						WithActive(true).
+						WithEmails([]model.Email{
+							model.EmailBuilder().WithValue("user.1@mail.com").WithType("work").WithPrimary(true).Build(),
+						}).
+						Build(),
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -683,6 +719,57 @@ func TestGetUsersByGroupsMembers(t *testing.T) {
 									Build(),
 							},
 						).
+						Build(),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should return UsersResult with filtered nil and no error",
+			prepare: func(f *fields) {
+				ctx := context.Background()
+				googleUser1 := &admin.User{
+					Id:           "1",
+					PrimaryEmail: "user.1@mail.com",
+					Name:         &admin.UserName{GivenName: "user", FamilyName: "1"},
+				}
+				googleUser2 := &admin.User{
+					Id:           "2",
+					PrimaryEmail: "", // Will cause buildUser to return nil
+					Name:         &admin.UserName{GivenName: "user", FamilyName: "2"},
+				}
+
+				gomock.InOrder(
+					f.ds.EXPECT().GetUser(ctx, gomock.Eq("user.1@mail.com")).Return(googleUser1, nil).Times(1),
+					f.ds.EXPECT().GetUser(ctx, gomock.Eq("user.2@mail.com")).Return(googleUser2, nil).Times(1),
+				)
+			},
+			args: args{
+				ctx: context.Background(),
+				gmr: &model.GroupsMembersResult{
+					Resources: []*model.GroupMembers{
+						{
+							Group: &model.Group{IPID: "1", Name: "group 1", Email: "group1@mail.com"},
+							Resources: []*model.Member{
+								{IPID: "1", Email: "user.1@mail.com", Status: "ACTIVE"},
+								{IPID: "2", Email: "user.2@mail.com", Status: "ACTIVE"},
+							},
+						},
+					},
+				},
+			},
+			want: &model.UsersResult{
+				Items: 1,
+				Resources: []*model.User{
+					model.UserBuilder().
+						WithIPID("1").
+						WithName(&model.Name{GivenName: "user", FamilyName: "1"}).
+						WithDisplayName("user 1").
+						WithActive(true).
+						WithUserName("user.1@mail.com").
+						WithEmails([]model.Email{
+							model.EmailBuilder().WithValue("user.1@mail.com").WithType("work").WithPrimary(true).Build(),
+						}).
 						Build(),
 				},
 			},

--- a/internal/model/group.go
+++ b/internal/model/group.go
@@ -81,6 +81,9 @@ func (gr GroupsResult) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, g := range gr.Resources {
+		if g == nil {
+			continue
+		}
 		if err := enc.Encode(g); err != nil {
 			return nil, err
 		}
@@ -135,6 +138,9 @@ func (gr *GroupsResult) SetHashCode() {
 	// order the resources by their hash code to be consistency always
 	// NOTE: review this, it may be a performance issue and may not be necessary
 	sort.Slice(copiedStruct.Resources, func(i, j int) bool {
+		if copiedStruct.Resources[i] == nil || copiedStruct.Resources[j] == nil {
+			return false
+		}
 		return copiedStruct.Resources[i].HashCode < copiedStruct.Resources[j].HashCode
 	})
 

--- a/internal/model/group.go
+++ b/internal/model/group.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"log/slog"
 	"sort"
 
 	"github.com/slashdevops/idp-scim-sync/internal/deepcopy"
@@ -81,7 +82,9 @@ func (gr GroupsResult) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, g := range gr.Resources {
+		//skip nil pointer
 		if g == nil {
+			slog.Warn("model: error getting group: nil group")
 			continue
 		}
 		if err := enc.Encode(g); err != nil {

--- a/internal/model/group_test.go
+++ b/internal/model/group_test.go
@@ -257,6 +257,19 @@ func TestGroupsResult_SetHashCode(t *testing.T) {
 	if gr5.HashCode != gr4.HashCode {
 		t.Errorf("GroupsResult.HashCode should be equal: gr5-> %s, gr4-> %s", gr5.HashCode, gr4.HashCode)
 	}
+
+	t.Run("with nil resources", func(t *testing.T) {
+		gr := GroupsResult{
+			Items:     3,
+			Resources: []*Group{g1, nil, g2},
+		}
+		// Should not panic
+		gr.SetHashCode()
+
+		if gr.HashCode == "" {
+			t.Errorf("GroupsResult.HashCode should not be empty")
+		}
+	})
 }
 
 func TestGroupsResult_MarshalJSON(t *testing.T) {

--- a/internal/model/member.go
+++ b/internal/model/member.go
@@ -88,6 +88,9 @@ func (mr MembersResult) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, member := range mr.Resources {
+		if member == nil {
+			continue
+		}
 		if err := enc.Encode(member); err != nil {
 			return nil, err
 		}
@@ -134,6 +137,9 @@ func (mr *MembersResult) SetHashCode() {
 	// order the resources by their hash code to be consistency always
 	// NOTE: review this, it may be a performance issue and may not be necessary
 	sort.Slice(copyStruct.Resources, func(i, j int) bool {
+		if copyStruct.Resources[i] == nil || copyStruct.Resources[j] == nil {
+			return false
+		}
 		return copyStruct.Resources[i].IPID < copyStruct.Resources[j].IPID
 	})
 
@@ -164,6 +170,9 @@ func (gm GroupMembers) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, member := range gm.Resources {
+		if member == nil {
+			continue
+		}
 		if err := enc.Encode(member); err != nil {
 			return nil, err
 		}
@@ -218,6 +227,9 @@ func (gm *GroupMembers) SetHashCode() {
 	// because this never could be empty and it is unique
 	// NOTE: review this, it may be a performance issue and may not be necessary
 	sort.Slice(copiedStruct.Resources, func(i, j int) bool {
+		if copiedStruct.Resources[i] == nil || copiedStruct.Resources[j] == nil {
+			return false
+		}
 		return copiedStruct.Resources[i].Email < copiedStruct.Resources[j].Email
 	})
 
@@ -241,6 +253,9 @@ func (gmr GroupsMembersResult) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, group := range gmr.Resources {
+		if group == nil {
+			continue
+		}
 		if err := enc.Encode(group); err != nil {
 			return nil, err
 		}
@@ -296,6 +311,9 @@ func (gmr *GroupsMembersResult) SetHashCode() {
 	// because this never could be empty and it is unique
 	// NOTE: review this, it may be a performance issue and may not be necessary
 	sort.Slice(copiedStruct.Resources, func(i, j int) bool {
+		if copiedStruct.Resources[i] == nil || copiedStruct.Resources[j] == nil {
+			return false
+		}
 		return copiedStruct.Resources[i].HashCode < copiedStruct.Resources[j].HashCode
 	})
 

--- a/internal/model/member.go
+++ b/internal/model/member.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"log/slog"
 	"sort"
 
 	"github.com/slashdevops/idp-scim-sync/internal/deepcopy"
@@ -88,7 +89,9 @@ func (mr MembersResult) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, member := range mr.Resources {
+		//skip nil pointer
 		if member == nil {
+			slog.Warn("model: member is nil")
 			continue
 		}
 		if err := enc.Encode(member); err != nil {
@@ -170,7 +173,9 @@ func (gm GroupMembers) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, member := range gm.Resources {
+		//skip nil pointer
 		if member == nil {
+			slog.Warn("model: member is nil")
 			continue
 		}
 		if err := enc.Encode(member); err != nil {
@@ -253,7 +258,9 @@ func (gmr GroupsMembersResult) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, group := range gmr.Resources {
+		//skip nil pointer
 		if group == nil {
+			slog.Warn("model: group is nil")
 			continue
 		}
 		if err := enc.Encode(group); err != nil {

--- a/internal/model/member_test.go
+++ b/internal/model/member_test.go
@@ -396,6 +396,19 @@ func TestGroupsMembersResult_SetHashCode(t *testing.T) {
 	if gmr5.HashCode != gmr4.HashCode {
 		t.Errorf("GroupsMembersResult.HashCode should be equal: gmr5-> %s, gmr4-> %s", gmr5.HashCode, gmr4.HashCode)
 	}
+
+	t.Run("with nil resources", func(t *testing.T) {
+		gmr := GroupsMembersResult{
+			Items:     3,
+			Resources: []*GroupMembers{gm1, nil, gm2},
+		}
+		// Should not panic
+		gmr.SetHashCode()
+
+		if gmr.HashCode == "" {
+			t.Errorf("GroupsMembersResult.HashCode should not be empty")
+		}
+	})
 }
 
 func TestGroupMembers_GobEncode(t *testing.T) {

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -524,6 +524,9 @@ func (ur UsersResult) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, u := range ur.Resources {
+		if u == nil {
+			continue
+		}
 		if err := enc.Encode(u); err != nil {
 			return nil, err
 		}
@@ -578,6 +581,9 @@ func (ur *UsersResult) SetHashCode() {
 	// order the resources by their hash code to be consistency always
 	// NOTE: review this, it may be a performance issue and may not be necessary
 	sort.Slice(copiedStruct.Resources, func(i, j int) bool {
+		if copiedStruct.Resources[i] == nil || copiedStruct.Resources[j] == nil {
+			return false
+		}
 		return copiedStruct.Resources[i].HashCode < copiedStruct.Resources[j].HashCode
 	})
 

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"log/slog"
 	"sort"
 
 	"github.com/slashdevops/idp-scim-sync/internal/deepcopy"
@@ -524,7 +525,9 @@ func (ur UsersResult) MarshalBinary() ([]byte, error) {
 	}
 
 	for _, u := range ur.Resources {
+		//skip nil pointer
 		if u == nil {
+			slog.Warn("model: error getting user: user does not exist")
 			continue
 		}
 		if err := enc.Encode(u); err != nil {

--- a/internal/model/user_test.go
+++ b/internal/model/user_test.go
@@ -894,6 +894,19 @@ func TestUsersResult_SetHashCode(t *testing.T) {
 			t.Errorf("UsersResult.HashCode should be equal: ur5-> %s, ur4-> %s", ur5.HashCode, ur4.HashCode)
 		}
 	})
+
+	t.Run("with nil resources", func(t *testing.T) {
+		ur := UsersResult{
+			Items:     3,
+			Resources: []*User{u1, nil, u2},
+		}
+		// Should not panic
+		ur.SetHashCode()
+
+		if ur.HashCode == "" {
+			t.Errorf("UsersResult.HashCode should not be empty")
+		}
+	})
 }
 
 func TestUser_GetPrimaryEmailAddress(t *testing.T) {


### PR DESCRIPTION
This PR addresses a critical stability issue where the application would crash with a runtime error: invalid memory address or nil pointer dereference. The root cause was identified as nil pointers being introduced into result slices when the Identity Provider returned users missing mandatory SCIM fields (like a primary email). These nil entries then triggered panics during deterministic sorting and hash calculation.

- Added checks within sort.Slice comparison functions for UsersResult, GroupsResult, MembersResult, GroupMembers, and GroupsMembersResult. It now safely handles nil elements instead of attempting to access their fields.
- Updated MarshalBinary (GOB encoder) for collection types to skip nil pointers. This prevents the gob library from failing during binary encoding, which is a crucial step for HashCode generation.
- Modified GetUsers and GetUsersByGroupsMembers to use append logic instead of pre-allocated slices. This ensures that if buildUser returns nil (due to validation failure), the entry is skipped entirely and never enters the system's data flow.
- Added warning logs to explicitly signal when and why an IdP member is being skipped.